### PR TITLE
This is a stub of the iOS clipboard logic.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
     unix,
     not(any(
         target_os = "macos",
+        target_os = "ios",
         target_os = "android",
         target_os = "emscripten"
     ))
@@ -12,6 +13,7 @@ mod platform;
 #[cfg(not(all(
     unix,
     not(any(
+        target_os = "ios",
         target_os = "macos",
         target_os = "android",
         target_os = "emscripten"

--- a/src/platform/not_linux.rs
+++ b/src/platform/not_linux.rs
@@ -46,11 +46,22 @@ mod clipboard_ios {
             Ok(Self)
         }
     }
+    #[derive(Debug)]
+    #[allow(non_camel_case_types)]
+    pub enum iOSClipboardError {
+        Unimplemented,
+    }
+    impl std::fmt::Display for iOSClipboardError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Unimplemented")
+        }
+    }
+    impl Error for iOSClipboardError { }
 }
 
 #[cfg(target_os = "ios")]
 impl ClipboardProvider for clipboard_ios::Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
-        unimplemented!();
+        Err(Box::new(clipboard_ios::iOSClipboardError::Unimplemented))
     }
 }

--- a/src/platform/not_linux.rs
+++ b/src/platform/not_linux.rs
@@ -15,6 +15,11 @@ pub fn new_clipboard<W: HasRawWindowHandle>(
     {
         Ok(Box::new(clipboard_macos::Clipboard::new()?))
     }
+
+    #[cfg(target_os = "ios")]
+    {
+        Ok(Box::new(clipboard_ios::Clipboard::new()?))
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -28,5 +33,24 @@ impl ClipboardProvider for clipboard_windows::Clipboard {
 impl ClipboardProvider for clipboard_macos::Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         self.read()
+    }
+}
+
+
+#[cfg(target_os = "ios")]
+mod clipboard_ios {
+    use std::error::Error;
+    pub struct Clipboard;
+    impl Clipboard {
+        pub fn new() -> Result<Clipboard, Box<dyn Error>> {
+            Ok(Self)
+        }
+    }
+}
+
+#[cfg(target_os = "ios")]
+impl ClipboardProvider for clipboard_ios::Clipboard {
+    fn read(&self) -> Result<String, Box<dyn Error>> {
+        unimplemented!();
     }
 }


### PR DESCRIPTION
This is a stub to make the iOS pull request for iced work with the latest master branch.

From what I can tell, mobile clipboards are a pain. It's more or less built into the UITextInput logic (you tap and hold and it pops up a "copy/paste" menu). It very well might be time to look into making the iOS support be a top level platform similar to the web stuff.