### PR TITLE
X11: use existing connection and window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["gui"]
 raw-window-handle = "0.3"
 
 [target.'cfg(windows)'.dependencies]
-clipboard-win = "2.1"
+clipboard-win = "3.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 clipboard_macos = { version = "0.1.0", path = "./macos" }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,1 @@
 max_width=80
-wrap_comments=true
-merge_imports=true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,19 @@ impl Clipboard {
         // Maybe we should make `read` mutable (?)
         self.raw.read()
     }
+
+    pub fn write(
+        &mut self,
+        string: std::borrow::Cow<str>,
+    ) -> Result<(), Box<dyn Error>> {
+        self.raw.write(string)
+    }
 }
 
 pub trait ClipboardProvider {
     fn read(&self) -> Result<String, Box<dyn Error>>;
+    fn write(
+        &mut self,
+        string: std::borrow::Cow<str>,
+    ) -> Result<(), Box<dyn Error>>;
 }

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -35,4 +35,11 @@ impl ClipboardProvider for Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::new(iOSClipboardError::Unimplemented))
     }
+
+    fn write(
+        &self,
+        _string: std::borrow::Cow<str>,
+    ) -> Result<(), Box<dyn Error>> {
+        Err(Box::new(iOSClipboardError::Unimplemented))
+    }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -2,25 +2,48 @@ use crate::ClipboardProvider;
 
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use std::error::Error;
+use std::fmt;
 
 pub use clipboard_wayland as wayland;
 pub use clipboard_x11 as x11;
 
+#[derive(Debug)]
+struct Unsupported(RawWindowHandle);
+
+impl std::error::Error for Unsupported {}
+
+impl fmt::Display for Unsupported {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Unsupported window handle: {:?}", self.0)
+    }
+}
+
 pub fn new_clipboard<W: HasRawWindowHandle>(
     window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
-    let clipboard = match window.raw_window_handle() {
+    match window.raw_window_handle() {
         RawWindowHandle::Wayland(handle) => {
             assert!(!handle.display.is_null());
-
-            Box::new(unsafe {
-                wayland::Clipboard::new(handle.display as *mut _)
-            }) as _
+            let clipboard =
+                unsafe { wayland::Clipboard::new(handle.display as *mut _) };
+            Ok(Box::new(clipboard))
         }
-        _ => Box::new(x11::Clipboard::new()?) as _,
-    };
-
-    Ok(clipboard)
+        RawWindowHandle::Xcb(handle) => {
+            assert!(!handle.connection.is_null());
+            let clipboard = unsafe {
+                x11::Clipboard::new_xcb(handle.connection, handle.window)?
+            };
+            Ok(Box::new(clipboard))
+        }
+        RawWindowHandle::Xlib(handle) => {
+            assert!(!handle.display.is_null());
+            let clipboard = unsafe {
+                x11::Clipboard::new_xlib(handle.display, handle.window)?
+            };
+            Ok(Box::new(clipboard))
+        }
+        h => Err(Box::new(Unsupported(h))),
+    }
 }
 
 impl ClipboardProvider for wayland::Clipboard {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -50,10 +50,24 @@ impl ClipboardProvider for wayland::Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         self.read()
     }
+
+    fn write(
+        &mut self,
+        string: std::borrow::Cow<str>,
+    ) -> Result<(), Box<dyn Error>> {
+        wayland::Clipboard::write(self, string.to_string())
+    }
 }
 
 impl ClipboardProvider for x11::Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         self.read()
+    }
+
+    fn write(
+        &mut self,
+        string: std::borrow::Cow<str>,
+    ) -> Result<(), Box<dyn Error>> {
+        x11::Clipboard::write(self, string.to_string())
     }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -30,16 +30,14 @@ pub fn new_clipboard<W: HasRawWindowHandle>(
         }
         RawWindowHandle::Xcb(handle) => {
             assert!(!handle.connection.is_null());
-            let clipboard = unsafe {
-                x11::Clipboard::new_xcb(handle.connection, handle.window)?
-            };
+            let clipboard =
+                unsafe { x11::Clipboard::new_xcb(handle.connection)? };
             Ok(Box::new(clipboard))
         }
         RawWindowHandle::Xlib(handle) => {
             assert!(!handle.display.is_null());
-            let clipboard = unsafe {
-                x11::Clipboard::new_xlib(handle.display, handle.window)?
-            };
+            let clipboard =
+                unsafe { x11::Clipboard::new_xlib(handle.display)? };
             Ok(Box::new(clipboard))
         }
         h => Err(Box::new(Unsupported(h))),

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -13,4 +13,11 @@ impl ClipboardProvider for clipboard_macos::Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         self.read()
     }
+
+    fn write(
+        &self,
+        _string: std::borrow::Cow<str>,
+    ) -> Result<(), Box<dyn Error>> {
+        // TODO
+    }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -15,9 +15,9 @@ impl ClipboardProvider for clipboard_macos::Clipboard {
     }
 
     fn write(
-        &self,
-        _string: std::borrow::Cow<str>,
+        &mut self,
+        string: std::borrow::Cow<str>,
     ) -> Result<(), Box<dyn Error>> {
-        // TODO
+        self.write(string.to_string())
     }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -17,4 +17,11 @@ impl ClipboardProvider for Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         Ok(get_clipboard_string()?)
     }
+
+    fn write(
+        &self,
+        _string: std::borrow::Cow<str>,
+    ) -> Result<(), Box<dyn Error>> {
+        // TODO
+    }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,6 +1,5 @@
 use crate::ClipboardProvider;
 
-use clipboard_win::get_clipboard_string;
 use raw_window_handle::HasRawWindowHandle;
 
 use std::error::Error;
@@ -15,13 +14,13 @@ pub struct Clipboard;
 
 impl ClipboardProvider for Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
-        Ok(get_clipboard_string()?)
+        Ok(clipboard_win::get_clipboard_string()?)
     }
 
     fn write(
-        &self,
-        _string: std::borrow::Cow<str>,
+        &mut self,
+        string: std::borrow::Cow<str>,
     ) -> Result<(), Box<dyn Error>> {
-        // TODO
+        Ok(clipboard_win::set_clipboard_string(&string)?)
     }
 }

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -10,4 +10,4 @@ documentation = "https://docs.rs/clipboard_x11"
 keywords = ["clipboard", "x11"]
 
 [dependencies]
-xcb = { version = "0.9", features = ["thread"] }
+xcb = { version = "0.9", features = ["thread", "xlib_xcb"] }

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -11,3 +11,4 @@ keywords = ["clipboard", "x11"]
 
 [dependencies]
 xcb = { version = "0.9", features = ["thread", "xlib_xcb"] }
+x11 = "2.18"

--- a/x11/src/clipboard.rs
+++ b/x11/src/clipboard.rs
@@ -114,22 +114,17 @@ impl Clipboard {
         T: Into<Option<Duration>>,
     {
         let mut is_incr = false;
-        let timeout = timeout.into();
-        let start_time = if timeout.is_some() {
-            Some(Instant::now())
+        let end_time = if let Some(dur) = timeout.into() {
+            Some(Instant::now() + dur)
         } else {
             None
         };
 
         loop {
-            if timeout
-                .into_iter()
-                .zip(start_time)
-                .next()
-                .map(|(timeout, time)| (Instant::now() - time) >= timeout)
-                .unwrap_or(false)
-            {
-                return Err(Error::Timeout);
+            if let Some(end) = end_time {
+                if Instant::now() > end {
+                    return Err(Error::Timeout);
+                }
             }
 
             let event = match self.getter.connection.poll_for_event() {

--- a/x11/src/error.rs
+++ b/x11/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     Set(SendError<Atom>),
     XcbConn(ConnError),
     XcbGeneric(GenericError),
+    Lock,
     Timeout,
     Owner,
     UnexpectedType(Atom),
@@ -21,6 +22,7 @@ impl fmt::Display for Error {
             Error::Set(e) => write!(f, "XCB - couldn't set atom: {:?}", e),
             Error::XcbConn(e) => write!(f, "XCB connection error: {:?}", e),
             Error::XcbGeneric(e) => write!(f, "XCB generic error: {:?}", e),
+            Error::Lock => write!(f, "XCB: Lock is poisoned"),
             Error::Timeout => write!(f, "Selection timed out"),
             Error::Owner => {
                 write!(f, "Failed to set new owner of XCB selection")
@@ -39,7 +41,7 @@ impl StdError for Error {
             Set(e) => Some(e),
             XcbConn(e) => Some(e),
             XcbGeneric(e) => Some(e),
-            Timeout | Owner | UnexpectedType(_) => None,
+            Lock | Timeout | Owner | UnexpectedType(_) => None,
         }
     }
 }

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -1,5 +1,6 @@
 mod clipboard;
 mod error;
+mod run;
 
 use std::ffi::c_void;
 pub use xcb::*;
@@ -22,7 +23,9 @@ impl Clipboard {
         connection: *mut c_void,
         window: Window,
     ) -> Result<Clipboard, Box<dyn Error>> {
-        Ok(Clipboard(clipboard::Clipboard::new_xcb(connection, window)?))
+        Ok(Clipboard(clipboard::Clipboard::new_xcb(
+            connection, window,
+        )?))
     }
 
     /// Read clipboard contents as a String
@@ -33,5 +36,14 @@ impl Clipboard {
             self.0.atoms.property,
             std::time::Duration::from_secs(3),
         )?)?)
+    }
+
+    /// Write clipboard contents from a String
+    pub fn write(&self, text: String) -> Result<(), Box<dyn Error>> {
+        Ok(self.0.store(
+            self.0.atoms.clipboard,
+            self.0.atoms.utf8_string,
+            text,
+        )?)
     }
 }

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -9,14 +9,14 @@ pub struct Clipboard(clipboard::Clipboard);
 
 impl Clipboard {
     pub fn new() -> Result<Clipboard, Box<dyn Error>> {
-        Ok(Clipboard(clipboard::Clipboard::new()?))
+        Ok(Clipboard(clipboard::Clipboard::new(None)?))
     }
 
     pub fn read(&self) -> Result<String, Box<dyn Error>> {
         Ok(String::from_utf8(self.0.load(
-            self.0.getter.atoms.clipboard,
-            self.0.getter.atoms.utf8_string,
-            self.0.getter.atoms.property,
+            self.0.atoms.clipboard,
+            self.0.atoms.utf8_string,
+            self.0.atoms.property,
             std::time::Duration::from_secs(3),
         )?)?)
     }

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -1,6 +1,7 @@
 mod clipboard;
 mod error;
 
+use std::ffi::c_void;
 pub use xcb::*;
 
 use std::error::Error;
@@ -8,10 +9,23 @@ use std::error::Error;
 pub struct Clipboard(clipboard::Clipboard);
 
 impl Clipboard {
-    pub fn new() -> Result<Clipboard, Box<dyn Error>> {
-        Ok(Clipboard(clipboard::Clipboard::new(None)?))
+    /// Create Clipboard from an XLib display and window
+    pub unsafe fn new_xlib(
+        display: *mut c_void,
+        window: u64,
+    ) -> Result<Clipboard, Box<dyn Error>> {
+        Ok(Clipboard(clipboard::Clipboard::new_xlib(display, window)?))
     }
 
+    /// Create Clipboard from an XCB connection and window
+    pub unsafe fn new_xcb(
+        connection: *mut c_void,
+        window: Window,
+    ) -> Result<Clipboard, Box<dyn Error>> {
+        Ok(Clipboard(clipboard::Clipboard::new_xcb(connection, window)?))
+    }
+
+    /// Read clipboard contents as a String
     pub fn read(&self) -> Result<String, Box<dyn Error>> {
         Ok(String::from_utf8(self.0.load(
             self.0.atoms.clipboard,

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -30,17 +30,16 @@ impl Clipboard {
 
     /// Read clipboard contents as a String
     pub fn read(&self) -> Result<String, Box<dyn Error>> {
-        Ok(String::from_utf8(self.0.load(
+        Ok(String::from_utf8(self.0.read(
             self.0.atoms.clipboard,
             self.0.atoms.utf8_string,
-            self.0.atoms.property,
             std::time::Duration::from_secs(3),
         )?)?)
     }
 
     /// Write clipboard contents from a String
     pub fn write(&self, text: String) -> Result<(), Box<dyn Error>> {
-        Ok(self.0.store(
+        Ok(self.0.write(
             self.0.atoms.clipboard,
             self.0.atoms.utf8_string,
             text,

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -13,19 +13,15 @@ impl Clipboard {
     /// Create Clipboard from an XLib display and window
     pub unsafe fn new_xlib(
         display: *mut c_void,
-        window: u64,
     ) -> Result<Clipboard, Box<dyn Error>> {
-        Ok(Clipboard(clipboard::Clipboard::new_xlib(display, window)?))
+        Ok(Clipboard(clipboard::Clipboard::new_xlib(display)?))
     }
 
     /// Create Clipboard from an XCB connection and window
     pub unsafe fn new_xcb(
         connection: *mut c_void,
-        window: Window,
     ) -> Result<Clipboard, Box<dyn Error>> {
-        Ok(Clipboard(clipboard::Clipboard::new_xcb(
-            connection, window,
-        )?))
+        Ok(Clipboard(clipboard::Clipboard::new_xcb(connection)?))
     }
 
     /// Read clipboard contents as a String

--- a/x11/src/run.rs
+++ b/x11/src/run.rs
@@ -1,0 +1,169 @@
+use std::cmp;
+use std::collections::HashMap;
+use std::sync::mpsc::Receiver;
+use std::sync::{Arc, RwLock};
+use xcb::{self, Atom, Connection};
+
+const INCR_CHUNK_SIZE: usize = 4000;
+
+pub type SetMap = Arc<RwLock<HashMap<Atom, (Atom, Vec<u8>)>>>;
+
+macro_rules! try_continue {
+    ( $expr:expr ) => {
+        match $expr {
+            Some(val) => val,
+            None => continue,
+        }
+    };
+}
+
+struct IncrState {
+    selection: Atom,
+    requestor: Atom,
+    property: Atom,
+    pos: usize,
+}
+
+pub fn run(
+    connection: &Arc<Connection>,
+    setmap: &SetMap,
+    targets: Atom,
+    incr: Atom,
+    max_length: usize,
+    receiver: &Receiver<Atom>,
+) {
+    let mut incr_map = HashMap::new();
+    let mut state_map = HashMap::new();
+
+    while let Some(event) = connection.wait_for_event() {
+        while let Ok(selection) = receiver.try_recv() {
+            if let Some(property) = incr_map.remove(&selection) {
+                state_map.remove(&property);
+            }
+        }
+
+        match event.response_type() & !0x80 {
+            xcb::SELECTION_REQUEST => {
+                let event = unsafe {
+                    xcb::cast_event::<xcb::SelectionRequestEvent>(&event)
+                };
+                let read_map = try_continue!(setmap.read().ok());
+                let &(target, ref value) =
+                    try_continue!(read_map.get(&event.selection()));
+
+                if event.target() == targets {
+                    xcb::change_property(
+                        &connection,
+                        xcb::PROP_MODE_REPLACE as u8,
+                        event.requestor(),
+                        event.property(),
+                        xcb::ATOM_ATOM,
+                        32,
+                        &[targets, target],
+                    );
+                } else if value.len() < max_length - 24 {
+                    xcb::change_property(
+                        &connection,
+                        xcb::PROP_MODE_REPLACE as u8,
+                        event.requestor(),
+                        event.property(),
+                        target,
+                        8,
+                        value,
+                    );
+                } else {
+                    xcb::change_window_attributes(
+                        &connection,
+                        event.requestor(),
+                        &[(
+                            xcb::CW_EVENT_MASK,
+                            xcb::EVENT_MASK_PROPERTY_CHANGE,
+                        )],
+                    );
+                    xcb::change_property(
+                        &connection,
+                        xcb::PROP_MODE_REPLACE as u8,
+                        event.requestor(),
+                        event.property(),
+                        incr,
+                        32,
+                        &[0u8; 0],
+                    );
+
+                    incr_map.insert(event.selection(), event.property());
+                    state_map.insert(
+                        event.property(),
+                        IncrState {
+                            selection: event.selection(),
+                            requestor: event.requestor(),
+                            property: event.property(),
+                            pos: 0,
+                        },
+                    );
+                }
+
+                xcb::send_event(
+                    &connection,
+                    false,
+                    event.requestor(),
+                    0,
+                    &xcb::SelectionNotifyEvent::new(
+                        event.time(),
+                        event.requestor(),
+                        event.selection(),
+                        event.target(),
+                        event.property(),
+                    ),
+                );
+                connection.flush();
+            }
+            xcb::PROPERTY_NOTIFY => {
+                let event = unsafe {
+                    xcb::cast_event::<xcb::PropertyNotifyEvent>(&event)
+                };
+                if event.state() != xcb::PROPERTY_DELETE as u8 {
+                    continue;
+                };
+
+                let is_end = {
+                    let state = try_continue!(state_map.get_mut(&event.atom()));
+                    let read_setmap = try_continue!(setmap.read().ok());
+                    let &(target, ref value) =
+                        try_continue!(read_setmap.get(&state.selection));
+
+                    let len =
+                        cmp::min(INCR_CHUNK_SIZE, value.len() - state.pos);
+                    xcb::change_property(
+                        &connection,
+                        xcb::PROP_MODE_REPLACE as u8,
+                        state.requestor,
+                        state.property,
+                        target,
+                        8,
+                        &value[state.pos..][..len],
+                    );
+
+                    state.pos += len;
+                    len == 0
+                };
+
+                if is_end {
+                    state_map.remove(&event.atom());
+                }
+                connection.flush();
+            }
+            xcb::SELECTION_CLEAR => {
+                let event = unsafe {
+                    xcb::cast_event::<xcb::SelectionClearEvent>(&event)
+                };
+                if let Some(property) = incr_map.remove(&event.selection()) {
+                    state_map.remove(&property);
+                }
+                if let Ok(mut write_setmap) = setmap.write() {
+                    write_setmap.remove(&event.selection());
+                }
+            }
+            _ => (),
+        }
+    }
+}


### PR DESCRIPTION
It turns out we can use the window reference on X11 too to avoid creating a fake window for *reading* a clipboard. After integrating into KAS for testing, this part appears to work; this may however *only* be because of the blocking design and event processing *normally* happening in the expected order...

I copied the `run` logic from https://github.com/quininer/x11-clipboard but using this same connection and tested in KAS, and of course the `run` thread eats most of the main thread's events. There's a reason `x11-clipboard` uses *two* new connections, each with a fake window (though I don't know if the `run` part actually requires a window or just the connection).

It seems that the *correct* way to make a clipboard work under X11 (and I think Wayland) is to handle these events within the application's main event loop. Making this work correctly via a standalone lib requires at least one new event loop, perhaps with a channel to send read results from the background event-loop thread to the `read` function.

Obviously, this implies that the "correct" solution is to integrate clipboard functionality into winit, either directly or as a plug-in attached to a sub-set of events, and that a cross-platform API must be asynchronous (and I'm not sure that futures cut it).

(All this for a broken clipboard API — it obviously requires a hack somewhere to let selections persist beyond application closure.)

CC @vberger (Wayland, https://github.com/rust-windowing/winit/issues/872): do you have thoughts on what the clipboard API should look like? Also see #2.