### PR TITLE
Add clipboard write support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clipboard_x11 = { version = "0.1", path = "./x11" }
 clipboard_wayland = { version = "0.1", path = "./wayland" }
 
 [dev-dependencies]
-winit = "0.22"
+winit = "0.23"
 
 [workspace]
 members = [

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,9 +15,17 @@ fn main() {
 
     let clipboard = Clipboard::new(&window).expect("Create clipboard");
 
+    let mut i = 0;
+
     event_loop.run(move |event, _, control_flow| match event {
         Event::MainEventsCleared => {
-            println!("{:?}", clipboard.read());
+            println!(
+                "write: {:?}",
+                clipboard.write(format!("hello world {}", i))
+            );
+            i += 1;
+
+            println!("read: {:?}", clipboard.read());
         }
         Event::WindowEvent {
             event: WindowEvent::CloseRequested,

--- a/macos/src/lib.rs
+++ b/macos/src/lib.rs
@@ -68,7 +68,7 @@ impl Clipboard {
         }
     }
 
-    pub fn write(&mut self, data: String) -> Result<(), Box<dyn Error>> {
+    pub fn write(&self, data: String) -> Result<(), Box<dyn Error>> {
         let string_array = NSArray::from_vec(vec![NSString::from_str(&data)]);
         let _: usize = unsafe { msg_send![self.pasteboard, clearContents] };
         let success: bool =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,13 @@ impl Clipboard {
         // Maybe we should make `read` mutable (?)
         self.raw.read()
     }
+
+    pub fn write(&self, s: String) -> Result<(), Box<dyn Error>> {
+        self.raw.write(s)
+    }
 }
 
 pub trait ClipboardProvider {
     fn read(&self) -> Result<String, Box<dyn Error>>;
+    fn write(&self, s: String) -> Result<(), Box<dyn Error>>;
 }

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -35,4 +35,8 @@ impl ClipboardProvider for Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::new(iOSClipboardError::Unimplemented))
     }
+
+    fn write(&self, s: String) -> Result<(), Box<dyn Error>> {
+        Err(Box::new(iOSClipboardError::Unimplemented))
+    }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -27,10 +27,18 @@ impl ClipboardProvider for wayland::Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         self.read()
     }
+
+    fn write(&self, s: String) -> Result<(), Box<dyn Error>> {
+        self.write(s)
+    }
 }
 
 impl ClipboardProvider for x11::Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         self.read()
+    }
+
+    fn write(&self, s: String) -> Result<(), Box<dyn Error>> {
+        self.write(s)
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -13,4 +13,8 @@ impl ClipboardProvider for clipboard_macos::Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         self.read()
     }
+
+    fn write(&self, s: String) -> Result<(), Box<dyn Error>> {
+        self.write(s)
+    }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,6 +1,6 @@
 use crate::ClipboardProvider;
 
-use clipboard_win::get_clipboard_string;
+use clipboard_win::{get_clipboard_string, set_clipboard_string};
 use raw_window_handle::HasRawWindowHandle;
 
 use std::error::Error;
@@ -16,5 +16,9 @@ pub struct Clipboard;
 impl ClipboardProvider for Clipboard {
     fn read(&self) -> Result<String, Box<dyn Error>> {
         Ok(get_clipboard_string()?)
+    }
+
+    fn write(&self, s: String) -> Result<(), Box<dyn Error>> {
+        Ok(set_clipboard_string(&*s)?)
     }
 }

--- a/wayland/src/lib.rs
+++ b/wayland/src/lib.rs
@@ -33,7 +33,7 @@ impl Clipboard {
         Ok(self.context.lock().unwrap().load()?)
     }
 
-    pub fn write(&mut self, data: String) -> Result<(), Box<dyn Error>> {
+    pub fn write(&self, data: String) -> Result<(), Box<dyn Error>> {
         self.context.lock().unwrap().store(data);
 
         Ok(())

--- a/x11/src/error.rs
+++ b/x11/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     Set(SendError<Atom>),
     XcbConn(ConnError),
     XcbGeneric(GenericError),
+    Lock,
     Timeout,
     Owner,
     UnexpectedType(Atom),
@@ -21,6 +22,7 @@ impl fmt::Display for Error {
             Error::Set(e) => write!(f, "XCB - couldn't set atom: {:?}", e),
             Error::XcbConn(e) => write!(f, "XCB connection error: {:?}", e),
             Error::XcbGeneric(e) => write!(f, "XCB generic error: {:?}", e),
+            Error::Lock => write!(f, "XCB: Lock is poisoned"),
             Error::Timeout => write!(f, "Selection timed out"),
             Error::Owner => {
                 write!(f, "Failed to set new owner of XCB selection")
@@ -39,7 +41,7 @@ impl StdError for Error {
             Set(e) => Some(e),
             XcbConn(e) => Some(e),
             XcbGeneric(e) => Some(e),
-            Timeout | Owner | UnexpectedType(_) => None,
+            Lock | Timeout | Owner | UnexpectedType(_) => None,
         }
     }
 }

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -20,4 +20,12 @@ impl Clipboard {
             std::time::Duration::from_secs(3),
         )?)?)
     }
+
+    pub fn write(&self, s: String) -> Result<(), Box<dyn Error>> {
+        Ok(self.0.store(
+            self.0.setter.atoms.clipboard,
+            self.0.setter.atoms.utf8_string,
+            s,
+        )?)
+    }
 }


### PR DESCRIPTION
Adds a `write` function to `ClipboardProvider`, I've tested on Linux X11/Wayland and on Windows (I don't have access to Mac).

This does seem to require quite a lot of additions to X11, I don't know if this is undesirable?