### PR TITLE
Replace `xcb` with `x11rb` in `clipboard_x11`

### DIFF
--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -10,4 +10,5 @@ documentation = "https://docs.rs/clipboard_x11"
 keywords = ["clipboard", "x11"]
 
 [dependencies]
-xcb = { version = "0.9", features = ["thread"] }
+x11rb = "0.8"
+thiserror = "1.0"

--- a/x11/src/error.rs
+++ b/x11/src/error.rs
@@ -1,59 +1,17 @@
-use std::error::Error as StdError;
-use std::fmt;
-use std::sync::mpsc::SendError;
-use xcb::base::{ConnError, GenericError};
-use xcb::Atom;
+use x11rb::errors::{ConnectError, ConnectionError, ReplyError};
+use x11rb::protocol::xproto::Atom;
 
 #[must_use]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    Set(SendError<Atom>),
-    XcbConn(ConnError),
-    XcbGeneric(GenericError),
+    #[error("connection failed: {0}")]
+    ConnectionFailed(#[from] ConnectError),
+    #[error("connection errored: {0}")]
+    ConnectionErrored(#[from] ConnectionError),
+    #[error("reply failed: {0}")]
+    ReplyError(#[from] ReplyError),
+    #[error("timeout")]
     Timeout,
-    Owner,
+    #[error("unexpected type: {0}")]
     UnexpectedType(Atom),
 }
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::Set(e) => write!(f, "XCB - couldn't set atom: {:?}", e),
-            Error::XcbConn(e) => write!(f, "XCB connection error: {:?}", e),
-            Error::XcbGeneric(e) => write!(f, "XCB generic error: {:?}", e),
-            Error::Timeout => write!(f, "Selection timed out"),
-            Error::Owner => {
-                write!(f, "Failed to set new owner of XCB selection")
-            }
-            Error::UnexpectedType(target) => {
-                write!(f, "Unexpected Reply type: {}", target)
-            }
-        }
-    }
-}
-
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        use self::Error::*;
-        match self {
-            Set(e) => Some(e),
-            XcbConn(e) => Some(e),
-            XcbGeneric(e) => Some(e),
-            Timeout | Owner | UnexpectedType(_) => None,
-        }
-    }
-}
-
-macro_rules! define_from {
-    ( $item:ident from $err:ty ) => {
-        impl From<$err> for Error {
-            fn from(err: $err) -> Error {
-                Error::$item(err)
-            }
-        }
-    };
-}
-
-define_from!(Set from SendError<Atom>);
-define_from!(XcbConn from ConnError);
-define_from!(XcbGeneric from GenericError);

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -1,8 +1,6 @@
 mod clipboard;
 mod error;
 
-pub use xcb::*;
-
 use std::error::Error;
 
 pub struct Clipboard(clipboard::Clipboard);

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -1,3 +1,4 @@
+#[forbid(unsafe_code)]
 mod clipboard;
 mod error;
 


### PR DESCRIPTION
This PR replaces the [`xcb`](https://github.com/rtbo/rust-xcb) dependency in `clipboard_x11` with [`x11rb`](https://github.com/psychon/x11rb).

`xcb` is unmaintained and recently [a security advisory was released exposing multiple soundness issues](https://rustsec.org/advisories/RUSTSEC-2021-0019.html).

We can also forbid unsafe code completely in `clipboard_x11` now.