### PR TITLE
More `x11rb` improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ clipboard_x11 = { version = "0.2", path = "./x11" }
 clipboard_wayland = { version = "0.1", path = "./wayland" }
 
 [dev-dependencies]
+rand = "0.8"
 winit = "0.23"
 
 [workspace]

--- a/examples/big_file.rs
+++ b/examples/big_file.rs
@@ -1,0 +1,54 @@
+use rand::distributions::{Alphanumeric, Distribution};
+use window_clipboard::Clipboard;
+use winit::{
+    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+};
+
+fn main() {
+    let mut rng = rand::thread_rng();
+
+    let data: String = Alphanumeric
+        .sample_iter(&mut rng)
+        .take(10_000_000)
+        .map(char::from)
+        .collect();
+
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_title("Press G to start the test!")
+        .build(&event_loop)
+        .unwrap();
+
+    let mut clipboard =
+        Clipboard::connect(&window).expect("Connect to clipboard");
+
+    clipboard.write(data.clone()).unwrap();
+
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::WindowEvent {
+            event:
+                WindowEvent::KeyboardInput {
+                    input:
+                        KeyboardInput {
+                            virtual_keycode: Some(VirtualKeyCode::G),
+                            state: ElementState::Released,
+                            ..
+                        },
+                    ..
+                },
+            ..
+        } => {
+            let new_data = clipboard.read().expect("Read data");
+            assert_eq!(data, new_data, "Data is equal");
+            println!("Data copied successfully!");
+        }
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            window_id,
+        } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+        _ => *control_flow = ControlFlow::Wait,
+    });
+}

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -22,7 +22,7 @@ const POLL_DURATION: std::time::Duration = Duration::from_micros(50);
 pub struct Clipboard {
     reader: Context,
     writer: Arc<Context>,
-    selections: Arc<RwLock<HashMap<Atom, (Atom, Vec<u8>)>>>,
+    selections: Arc<RwLock<HashMap<Atom, (Atom, Vec<u32>)>>>,
     worker: mpsc::Sender<Atom>,
 }
 
@@ -71,7 +71,7 @@ impl Clipboard {
         self.selections
             .write()
             .map_err(|_| Error::SelectionLocked)?
-            .insert(selection, (target, contents.into()));
+            .insert(selection, (target, contents.chars().map(u32::from).collect()));
 
         let _ = xproto::set_selection_owner(
             &self.writer.connection,
@@ -343,7 +343,7 @@ impl Context {
 
 pub struct Worker {
     context: Arc<Context>,
-    selections: Arc<RwLock<HashMap<Atom, (Atom, Vec<u8>)>>>,
+    selections: Arc<RwLock<HashMap<Atom, (Atom, Vec<u32>)>>>,
     receiver: mpsc::Receiver<Atom>,
 }
 
@@ -363,7 +363,7 @@ impl Worker {
         let mut incr_map = HashMap::new();
         let mut state_map = HashMap::new();
 
-        let max_length = self.context.connection.maximum_request_bytes() * 4;
+        let max_length = self.context.connection.maximum_request_bytes();
 
         while let Ok(event) = self.context.connection.wait_for_event() {
             while let Ok(selection) = self.receiver.try_recv() {
@@ -396,8 +396,8 @@ impl Worker {
                             &data,
                         )
                         .expect("Change property");
-                    } else if value.len() < max_length - 24 {
-                        let _ = self.context.connection.change_property8(
+                    } else if value.len() < max_length {
+                        let _ = self.context.connection.change_property32(
                             xproto::PropMode::REPLACE,
                             event.requestor,
                             event.property,
@@ -481,7 +481,7 @@ impl Worker {
                             value.len() - state.pos,
                         );
 
-                        let _ = self.context.connection.change_property8(
+                        let _ = self.context.connection.change_property32(
                             xproto::PropMode::REPLACE,
                             state.requestor,
                             state.property,

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -3,7 +3,7 @@ mod error;
 
 pub use error::Error;
 
-use x11rb::connection::{Connection as _, RequestConnection};
+use x11rb::connection::Connection as _;
 use x11rb::errors::ConnectError;
 use x11rb::protocol::xproto::{self, Atom, AtomEnum, Window};
 use x11rb::protocol::Event;


### PR DESCRIPTION
I wrote an example to make sure that copying large amounts of data work.

- The example generated 10 MB of data
- Writing more then 10 MB to the clipboard isn't possible, it wasn't before either
- I tested reading more then 100 MB from the clipboard with this code, which works great

Builds on top of #13.