### PR TITLE
Update raw-window-handle to v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["clipboard", "window", "ui", "gui", "raw-window-handle"]
 categories = ["gui"]
 
 [dependencies]
-raw-window-handle = "0.3"
+raw-window-handle = "0.5"
 thiserror = "1.0"
 
 [target.'cfg(windows)'.dependencies]
@@ -27,7 +27,7 @@ clipboard_wayland = { version = "0.2", path = "./wayland" }
 
 [dev-dependencies]
 rand = "0.8"
-winit = "0.23"
+winit = "0.27"
 
 [workspace]
 members = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod platform;
 #[path = "platform/dummy.rs"]
 mod platform;
 
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::HasRawDisplayHandle;
 use std::error::Error;
 
 pub struct Clipboard {
@@ -52,7 +52,7 @@ pub struct Clipboard {
 }
 
 impl Clipboard {
-    pub fn connect<W: HasRawWindowHandle>(
+    pub fn connect<W: HasRawDisplayHandle>(
         window: &W,
     ) -> Result<Self, Box<dyn Error>> {
         let raw = platform::connect(window)?;

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,9 +1,9 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::HasRawDisplayHandle;
 use std::error::Error;
 
-pub fn connect<W: HasRawWindowHandle>(
+pub fn connect<W: HasRawDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
     Ok(Box::new(Clipboard::new()?))

--- a/src/platform/dummy.rs
+++ b/src/platform/dummy.rs
@@ -1,10 +1,10 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::HasRawDisplayHandle;
 
 struct Dummy;
 
-pub fn connect<W: HasRawWindowHandle>(
+pub fn connect<W: HasRawDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn std::error::Error>> {
     Ok(Box::new(Dummy))

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -1,9 +1,9 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::HasRawDisplayHandle;
 use std::error::Error;
 
-pub fn connect<W: HasRawWindowHandle>(
+pub fn connect<W: HasRawDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
     Ok(Box::new(Clipboard::new()?))

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1,16 +1,16 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
 use std::error::Error;
 
 pub use clipboard_wayland as wayland;
 pub use clipboard_x11 as x11;
 
-pub fn connect<W: HasRawWindowHandle>(
+pub fn connect<W: HasRawDisplayHandle>(
     window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
-    let clipboard = match window.raw_window_handle() {
-        RawWindowHandle::Wayland(handle) => {
+    let clipboard = match window.raw_display_handle() {
+        RawDisplayHandle::Wayland(handle) => {
             assert!(!handle.display.is_null());
 
             Box::new(unsafe {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,9 +1,9 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::HasRawDisplayHandle;
 use std::error::Error;
 
-pub fn connect<W: HasRawWindowHandle>(
+pub fn connect<W: HasRawDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
     Ok(Box::new(clipboard_macos::Clipboard::new()?))

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,11 +1,11 @@
 use crate::ClipboardProvider;
 
 use clipboard_win::{get_clipboard_string, set_clipboard_string};
-use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::HasRawDisplayHandle;
 
 use std::error::Error;
 
-pub fn connect<W: HasRawWindowHandle>(
+pub fn connect<W: HasRawDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
     Ok(Box::new(Clipboard))


### PR DESCRIPTION
Update raw-window-handle to v0.5. This mainly consisted of using the
newly added RawDisplayHandle trait instead of the previously used
RawWindowHandle trait. For the Linux implementation, this also included
updating winit to v0.27

Context: I am trying to update a rust game to winit v0.27, because that fixes a nasty bug, but raw-window-handle v0.3 is holding me back. The game uses your library and thus also uses raw-window-handle v0.3.