### PR TITLE
Use dummy platform for Redox OS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ clipboard-win = { version = "4.0", features = ["std"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 clipboard_macos = { version = "0.1", path = "./macos" }
 
-[target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten", target_os="ios"))))'.dependencies]
+[target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten", target_os="ios", target_os="redox"))))'.dependencies]
 clipboard_x11 = { version = "0.4", path = "./x11" }
 clipboard_wayland = { version = "0.2", path = "./wayland" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
         target_os = "macos",
         target_os = "ios",
         target_os = "android",
-        target_os = "emscripten"
+        target_os = "emscripten",
+        target_os = "redox"
     ))
 ))]
 #[path = "platform/linux.rs"]
@@ -33,7 +34,8 @@ mod platform;
             target_os = "macos",
             target_os = "ios",
             target_os = "android",
-            target_os = "emscripten"
+            target_os = "emscripten",
+            target_os = "redox"
         ))
     ),
     target_os = "windows",


### PR DESCRIPTION
This fixes compilation on Redox OS. Clipboard support will be available later after changes to the orbital window server.