### PR TITLE
Raw window handle 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clipboard_wayland = { version = "0.2", path = "./wayland" }
 
 [dev-dependencies]
 rand = "0.8"
-winit = "0.28"
+winit = { version = "0.29", features = ["rwh_05"] }
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ raw-window-handle = "0.5"
 thiserror = "1.0"
 
 [target.'cfg(windows)'.dependencies]
-clipboard-win = { version = "4.0", features = ["std"] }
+clipboard-win = { version = "5.0", features = ["std"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 clipboard_macos = { version = "0.1", path = "./macos" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["clipboard", "window", "ui", "gui", "raw-window-handle"]
 categories = ["gui"]
 
 [dependencies]
-raw-window-handle = "0.6"
+raw-window-handle = { version = "0.6", features = ["std"] }
 thiserror = "1.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["clipboard", "window", "ui", "gui", "raw-window-handle"]
 categories = ["gui"]
 
 [dependencies]
-raw-window-handle = "0.5"
+raw-window-handle = "0.6"
 thiserror = "1.0"
 
 [target.'cfg(windows)'.dependencies]
@@ -27,7 +27,7 @@ clipboard_wayland = { version = "0.2", path = "./wayland" }
 
 [dev-dependencies]
 rand = "0.8"
-winit = { version = "0.29", features = ["rwh_05"] }
+winit = "0.29"
 
 [workspace]
 members = [

--- a/examples/big_file.rs
+++ b/examples/big_file.rs
@@ -1,8 +1,9 @@
 use rand::distributions::{Alphanumeric, Distribution};
 use window_clipboard::Clipboard;
 use winit::{
-    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event::{ElementState, Event, KeyEvent, WindowEvent},
+    event_loop::EventLoop,
+    keyboard::Key,
     window::WindowBuilder,
 };
 
@@ -15,7 +16,7 @@ fn main() {
         .map(char::from)
         .collect();
 
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("Press G to start the test!")
@@ -27,28 +28,30 @@ fn main() {
 
     clipboard.write(data.clone()).unwrap();
 
-    event_loop.run(move |event, _, control_flow| match event {
-        Event::WindowEvent {
-            event:
-                WindowEvent::KeyboardInput {
-                    input:
-                        KeyboardInput {
-                            virtual_keycode: Some(VirtualKeyCode::G),
-                            state: ElementState::Released,
-                            ..
-                        },
-                    ..
-                },
-            ..
-        } => {
-            let new_data = clipboard.read().expect("Read data");
-            assert_eq!(data, new_data, "Data is equal");
-            println!("Data copied successfully!");
-        }
-        Event::WindowEvent {
-            event: WindowEvent::CloseRequested,
-            window_id,
-        } if window_id == window.id() => *control_flow = ControlFlow::Exit,
-        _ => *control_flow = ControlFlow::Wait,
-    });
+    event_loop
+        .run(move |event, elwt| match event {
+            Event::WindowEvent {
+                event:
+                    WindowEvent::KeyboardInput {
+                        event:
+                            KeyEvent {
+                                logical_key: Key::Character(c),
+                                state: ElementState::Released,
+                                ..
+                            },
+                        ..
+                    },
+                ..
+            } if c == "G" => {
+                let new_data = clipboard.read().expect("Read data");
+                assert_eq!(data, new_data, "Data is equal");
+                println!("Data copied successfully!");
+            }
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => elwt.exit(),
+            _ => {}
+        })
+        .unwrap();
 }

--- a/examples/big_file.rs
+++ b/examples/big_file.rs
@@ -1,13 +1,14 @@
 use rand::distributions::{Alphanumeric, Distribution};
 use window_clipboard::Clipboard;
 use winit::{
+    error::EventLoopError,
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
     window::WindowBuilder,
 };
 
-fn main() {
+fn main() -> Result<(), EventLoopError> {
     let mut rng = rand::thread_rng();
 
     let data: String = Alphanumeric
@@ -28,30 +29,28 @@ fn main() {
 
     clipboard.write(data.clone()).unwrap();
 
-    event_loop
-        .run(move |event, elwt| match event {
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: Key::Character(c),
-                                state: ElementState::Released,
-                                ..
-                            },
-                        ..
-                    },
-                ..
-            } if c == "G" => {
-                let new_data = clipboard.read().expect("Read data");
-                assert_eq!(data, new_data, "Data is equal");
-                println!("Data copied successfully!");
-            }
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                window_id,
-            } if window_id == window.id() => elwt.exit(),
-            _ => {}
-        })
-        .unwrap();
+    event_loop.run(move |event, elwt| match event {
+        Event::WindowEvent {
+            event:
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            logical_key: Key::Character(c),
+                            state: ElementState::Released,
+                            ..
+                        },
+                    ..
+                },
+            ..
+        } if c == "G" => {
+            let new_data = clipboard.read().expect("Read data");
+            assert_eq!(data, new_data, "Data is equal");
+            println!("Data copied successfully!");
+        }
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            window_id,
+        } if window_id == window.id() => elwt.exit(),
+        _ => {}
+    })
 }

--- a/examples/big_file.rs
+++ b/examples/big_file.rs
@@ -24,7 +24,7 @@ fn main() {
         .unwrap();
 
     let mut clipboard =
-        Clipboard::connect(&window).expect("Connect to clipboard");
+        unsafe { Clipboard::connect(&window) }.expect("Connect to clipboard");
 
     clipboard.write(data.clone()).unwrap();
 

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -1,11 +1,12 @@
 use window_clipboard::Clipboard;
 use winit::{
+    error::EventLoopError,
     event::{Event, WindowEvent},
     event_loop::EventLoop,
     window::WindowBuilder,
 };
 
-fn main() {
+fn main() -> Result<(), EventLoopError> {
     let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
@@ -16,16 +17,14 @@ fn main() {
     let clipboard =
         unsafe { Clipboard::connect(&window) }.expect("Connect to clipboard");
 
-    event_loop
-        .run(move |event, elwt| match event {
-            Event::AboutToWait => {
-                println!("{:?}", clipboard.read());
-            }
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                window_id,
-            } if window_id == window.id() => elwt.exit(),
-            _ => {}
-        })
-        .unwrap();
+    event_loop.run(move |event, elwt| match event {
+        Event::AboutToWait => {
+            println!("{:?}", clipboard.read());
+        }
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            window_id,
+        } if window_id == window.id() => elwt.exit(),
+        _ => {}
+    })
 }

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -13,7 +13,8 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let clipboard = Clipboard::connect(&window).expect("Connect to clipboard");
+    let clipboard =
+        unsafe { Clipboard::connect(&window) }.expect("Connect to clipboard");
 
     event_loop
         .run(move |event, elwt| match event {

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -1,12 +1,12 @@
 use window_clipboard::Clipboard;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
 fn main() {
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -15,14 +15,16 @@ fn main() {
 
     let clipboard = Clipboard::connect(&window).expect("Connect to clipboard");
 
-    event_loop.run(move |event, _, control_flow| match event {
-        Event::MainEventsCleared => {
-            println!("{:?}", clipboard.read());
-        }
-        Event::WindowEvent {
-            event: WindowEvent::CloseRequested,
-            window_id,
-        } if window_id == window.id() => *control_flow = ControlFlow::Exit,
-        _ => *control_flow = ControlFlow::Wait,
-    });
+    event_loop
+        .run(move |event, elwt| match event {
+            Event::AboutToWait => {
+                println!("{:?}", clipboard.read());
+            }
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => elwt.exit(),
+            _ => {}
+        })
+        .unwrap();
 }

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -14,7 +14,7 @@ fn main() {
         .unwrap();
 
     let mut clipboard =
-        Clipboard::connect(&window).expect("Connect to clipboard");
+        unsafe { Clipboard::connect(&window) }.expect("Connect to clipboard");
 
     clipboard
         .write(String::from("Hello, world!"))

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -1,11 +1,12 @@
 use window_clipboard::Clipboard;
 use winit::{
+    error::EventLoopError,
     event::{Event, WindowEvent},
     event_loop::EventLoop,
     window::WindowBuilder,
 };
 
-fn main() {
+fn main() -> Result<(), EventLoopError> {
     let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
@@ -20,13 +21,11 @@ fn main() {
         .write(String::from("Hello, world!"))
         .expect("Write to clipboard");
 
-    event_loop
-        .run(move |event, elwt| match event {
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                window_id,
-            } if window_id == window.id() => elwt.exit(),
-            _ => {}
-        })
-        .unwrap();
+    event_loop.run(move |event, elwt| match event {
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            window_id,
+        } if window_id == window.id() => elwt.exit(),
+        _ => {}
+    })
 }

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -1,12 +1,12 @@
 use window_clipboard::Clipboard;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
 fn main() {
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -20,12 +20,13 @@ fn main() {
         .write(String::from("Hello, world!"))
         .expect("Write to clipboard");
 
-    event_loop.run(move |event, _, control_flow| match event {
-        Event::MainEventsCleared => {}
-        Event::WindowEvent {
-            event: WindowEvent::CloseRequested,
-            window_id,
-        } if window_id == window.id() => *control_flow = ControlFlow::Exit,
-        _ => *control_flow = ControlFlow::Wait,
-    });
+    event_loop
+        .run(move |event, elwt| match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => elwt.exit(),
+            _ => {}
+        })
+        .unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ mod platform;
 #[path = "platform/dummy.rs"]
 mod platform;
 
-use raw_window_handle::HasRawDisplayHandle;
+use raw_window_handle::HasDisplayHandle;
 use std::error::Error;
 
 pub struct Clipboard {
@@ -54,7 +54,8 @@ pub struct Clipboard {
 }
 
 impl Clipboard {
-    pub fn connect<W: HasRawDisplayHandle>(
+    /// Safety: the display handle must be valid for the lifetime of `Clipboard`
+    pub unsafe fn connect<W: HasDisplayHandle>(
         window: &W,
     ) -> Result<Self, Box<dyn Error>> {
         let raw = platform::connect(window)?;

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,9 +1,9 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::HasRawDisplayHandle;
+use raw_window_handle::HasDisplayHandle;
 use std::error::Error;
 
-pub fn connect<W: HasRawDisplayHandle>(
+pub fn connect<W: HasDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
     Ok(Box::new(Clipboard::new()?))

--- a/src/platform/dummy.rs
+++ b/src/platform/dummy.rs
@@ -1,10 +1,10 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::HasRawDisplayHandle;
+use raw_window_handle::HasDisplayHandle;
 
 struct Dummy;
 
-pub fn connect<W: HasRawDisplayHandle>(
+pub fn connect<W: HasDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn std::error::Error>> {
     Ok(Box::new(Dummy))

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -1,9 +1,9 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::HasRawDisplayHandle;
+use raw_window_handle::HasDisplayHandle;
 use std::error::Error;
 
-pub fn connect<W: HasRawDisplayHandle>(
+pub fn connect<W: HasDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
     Ok(Box::new(Clipboard::new()?))

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -10,13 +10,9 @@ pub fn connect<W: HasRawDisplayHandle>(
     window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
     let clipboard = match window.raw_display_handle() {
-        RawDisplayHandle::Wayland(handle) => {
-            assert!(!handle.display.is_null());
-
-            Box::new(unsafe {
-                wayland::Clipboard::connect(handle.display as *mut _)
-            }) as _
-        }
+        Ok(RawDisplayHandle::Wayland(handle)) => Box::new(unsafe {
+            wayland::Clipboard::connect(handle.display.as_ptr())
+        }) as _,
         _ => Box::new(x11::Clipboard::connect()?) as _,
     };
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1,18 +1,18 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
+use raw_window_handle::{HasDisplayHandle, RawDisplayHandle};
 use std::error::Error;
 
 pub use clipboard_wayland as wayland;
 pub use clipboard_x11 as x11;
 
-pub fn connect<W: HasRawDisplayHandle>(
+pub unsafe fn connect<W: HasDisplayHandle>(
     window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
-    let clipboard = match window.raw_display_handle() {
-        Ok(RawDisplayHandle::Wayland(handle)) => Box::new(unsafe {
-            wayland::Clipboard::connect(handle.display.as_ptr())
-        }) as _,
+    let clipboard = match window.display_handle()?.as_raw() {
+        RawDisplayHandle::Wayland(handle) => {
+            Box::new(wayland::Clipboard::connect(handle.display.as_ptr())) as _
+        }
         _ => Box::new(x11::Clipboard::connect()?) as _,
     };
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,9 +1,9 @@
 use crate::ClipboardProvider;
 
-use raw_window_handle::HasRawDisplayHandle;
+use raw_window_handle::HasDisplayHandle;
 use std::error::Error;
 
-pub fn connect<W: HasRawDisplayHandle>(
+pub fn connect<W: HasDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
     Ok(Box::new(clipboard_macos::Clipboard::new()?))

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,11 +1,11 @@
 use crate::ClipboardProvider;
 
 use clipboard_win::{get_clipboard_string, set_clipboard_string};
-use raw_window_handle::HasRawDisplayHandle;
+use raw_window_handle::HasDisplayHandle;
 
 use std::error::Error;
 
-pub fn connect<W: HasRawDisplayHandle>(
+pub fn connect<W: HasDisplayHandle>(
     _window: &W,
 ) -> Result<Box<dyn ClipboardProvider>, Box<dyn Error>> {
     Ok(Box::new(Clipboard))

--- a/wayland/Cargo.toml
+++ b/wayland/Cargo.toml
@@ -10,4 +10,4 @@ documentation = "https://docs.rs/clipboard_wayland"
 keywords = ["clipboard", "wayland"]
 
 [dependencies]
-smithay-clipboard = "0.6"
+smithay-clipboard = "0.7"

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -10,5 +10,5 @@ documentation = "https://docs.rs/clipboard_x11"
 keywords = ["clipboard", "x11"]
 
 [dependencies]
-x11rb = "0.11"
+x11rb = "0.13"
 thiserror = "1.0"


### PR DESCRIPTION
Includes https://github.com/hecrj/window_clipboard/pull/23. So there are no outdated dependencies.

Currently `connect` is unsafe, so it doesn't enforce the lifetime of the display. (It already was unsafe, it just wasn't marked as such.)

Closes #23.