### PR TITLE
Add support for Primary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,10 +69,30 @@ impl Clipboard {
     pub fn write(&mut self, contents: String) -> Result<(), Box<dyn Error>> {
         self.raw.write(contents)
     }
+
+    #[cfg(target_family = "unix")]
+    pub fn read_primary(&self) -> Result<String, Box<dyn Error>> {
+        self.raw.read_primary()
+    }
+
+    #[cfg(target_family = "unix")]
+    pub fn write_primary(
+        &mut self,
+        contents: String,
+    ) -> Result<(), Box<dyn Error>> {
+        self.raw.write_primary(contents)
+    }
 }
 
 pub trait ClipboardProvider {
     fn read(&self) -> Result<String, Box<dyn Error>>;
 
     fn write(&mut self, contents: String) -> Result<(), Box<dyn Error>>;
+
+    #[cfg(target_family = "unix")]
+    fn read_primary(&self) -> Result<String, Box<dyn Error>>;
+
+    #[cfg(target_family = "unix")]
+    fn write_primary(&mut self, contents: String)
+        -> Result<(), Box<dyn Error>>;
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -31,6 +31,18 @@ impl ClipboardProvider for wayland::Clipboard {
     fn write(&mut self, contents: String) -> Result<(), Box<dyn Error>> {
         self.write(contents)
     }
+    #[cfg(target_family = "unix")]
+    fn read_primary(&self) -> Result<String, Box<dyn Error>> {
+        self.read_primary()
+    }
+
+    #[cfg(target_family = "unix")]
+    fn write_primary(
+        &mut self,
+        contents: String,
+    ) -> Result<(), Box<dyn Error>> {
+        self.write_primary(contents)
+    }
 }
 
 impl ClipboardProvider for x11::Clipboard {
@@ -40,5 +52,18 @@ impl ClipboardProvider for x11::Clipboard {
 
     fn write(&mut self, contents: String) -> Result<(), Box<dyn Error>> {
         self.write(contents).map_err(Box::from)
+    }
+
+    #[cfg(target_family = "unix")]
+    fn read_primary(&self) -> Result<String, Box<dyn Error>> {
+        self.read_primary().map_err(Box::from)
+    }
+
+    #[cfg(target_family = "unix")]
+    fn write_primary(
+        &mut self,
+        contents: String,
+    ) -> Result<(), Box<dyn Error>> {
+        self.write_primary(contents).map_err(Box::from)
     }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -31,12 +31,11 @@ impl ClipboardProvider for wayland::Clipboard {
     fn write(&mut self, contents: String) -> Result<(), Box<dyn Error>> {
         self.write(contents)
     }
-    #[cfg(target_family = "unix")]
+
     fn read_primary(&self) -> Result<String, Box<dyn Error>> {
         self.read_primary()
     }
 
-    #[cfg(target_family = "unix")]
     fn write_primary(
         &mut self,
         contents: String,
@@ -54,12 +53,10 @@ impl ClipboardProvider for x11::Clipboard {
         self.write(contents).map_err(Box::from)
     }
 
-    #[cfg(target_family = "unix")]
     fn read_primary(&self) -> Result<String, Box<dyn Error>> {
         self.read_primary().map_err(Box::from)
     }
 
-    #[cfg(target_family = "unix")]
     fn write_primary(
         &mut self,
         contents: String,

--- a/wayland/src/lib.rs
+++ b/wayland/src/lib.rs
@@ -39,12 +39,10 @@ impl Clipboard {
         Ok(())
     }
 
-    #[cfg(target_family = "unix")]
     pub fn read_primary(&self) -> Result<String, Box<dyn Error>> {
         Ok(self.context.lock().unwrap().load_primary()?)
     }
 
-    #[cfg(target_family = "unix")]
     pub fn write_primary(
         &mut self,
         data: String,

--- a/wayland/src/lib.rs
+++ b/wayland/src/lib.rs
@@ -38,4 +38,19 @@ impl Clipboard {
 
         Ok(())
     }
+
+    #[cfg(target_family = "unix")]
+    pub fn read_primary(&self) -> Result<String, Box<dyn Error>> {
+        Ok(self.context.lock().unwrap().load_primary()?)
+    }
+
+    #[cfg(target_family = "unix")]
+    pub fn write_primary(
+        &mut self,
+        data: String,
+    ) -> Result<(), Box<dyn Error>> {
+        self.context.lock().unwrap().store_primary(data);
+
+        Ok(())
+    }
 }

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -45,10 +45,9 @@ impl Clipboard {
         })
     }
 
-    /// Read the current [`Clipboard`] value.
-    pub fn read(&self) -> Result<String, Error> {
+    fn read_x11(&self, selection: Atom) -> Result<String, Error> {
         Ok(String::from_utf8(self.load(
-            self.reader.atoms.clipboard,
+            selection,
             self.reader.atoms.utf8_string,
             self.reader.atoms.property,
             std::time::Duration::from_secs(3),
@@ -56,9 +55,11 @@ impl Clipboard {
         .map_err(Error::InvalidUtf8)?)
     }
 
-    /// Write a new value to the [`Clipboard`].
-    pub fn write(&mut self, contents: String) -> Result<(), Error> {
-        let selection = self.writer.atoms.clipboard;
+    fn write_x11(
+        &mut self,
+        contents: String,
+        selection: Atom,
+    ) -> Result<(), Error> {
         let target = self.writer.atoms.utf8_string;
 
         self.selections
@@ -85,6 +86,26 @@ impl Clipboard {
         } else {
             Err(Error::InvalidOwner)
         }
+    }
+
+    /// Read the current [`Clipboard`] value.
+    pub fn read(&self) -> Result<String, Error> {
+        self.read_x11(self.reader.atoms.clipboard)
+    }
+
+    /// Write a new value to the [`Clipboard`].
+    pub fn write(&mut self, contents: String) -> Result<(), Error> {
+        self.write_x11(contents, self.writer.atoms.clipboard)
+    }
+
+    /// Read the current Primary value.
+    pub fn read_primary(&self) -> Result<String, Error> {
+        self.read_x11(self.reader.atoms.primary)
+    }
+
+    /// Write a new value to Primary.
+    pub fn write_primary(&mut self, contents: String) -> Result<(), Error> {
+        self.write_x11(contents, self.writer.atoms.primary)
     }
 
     /// load value.


### PR DESCRIPTION
As part of fixing https://github.com/pop-os/cosmic-term/issues/49 , I have added support for the Primary clipboard. 

It is behind `#[cfg(target_family = "unix")]` since I think it only makes sense on unix.

Note: Since cosmic-term is using window_clipboard 0.3, I have coded this patch against that version, but I think it should apply cleanly against master also. 