### PR TITLE
Use `objc2` and its framework crates

### DIFF
--- a/macos/Cargo.toml
+++ b/macos/Cargo.toml
@@ -13,6 +13,10 @@ keywords = ["clipboard", "macos"]
 default-target = "x86_64-apple-darwin"
 
 [dependencies]
-objc = "0.2"
-objc_id = "0.1"
-objc-foundation = "0.1"
+objc2 = "0.5.1"
+objc2-foundation = { version = "0.2.0", features = [
+    "NSArray",
+    "NSString",
+    "NSURL",
+] }
+objc2-app-kit = { version = "0.2.0", features = ["NSPasteboard"] }


### PR DESCRIPTION
[`objc2`](https://github.com/madsmtm/objc2) is a replacement for `objc`/`objc_id` that contains a bunch of safety improvements, including `msg_send_id!` which ensures that we uphold memory management rules correctly, and `objc2-app-kit` which is an automatically generated interface to AppKit.

Concretely, this fixes a leak in the passing of the `NSArray` to `writeObjects`.