### PR TITLE
Prepare for `objc2` frameworks v0.3

### DIFF
--- a/macos/Cargo.toml
+++ b/macos/Cargo.toml
@@ -14,9 +14,13 @@ default-target = "x86_64-apple-darwin"
 
 [dependencies]
 objc2 = "0.5.1"
-objc2-foundation = { version = "0.2.0", features = [
+objc2-foundation = { version = "0.2.0", default-features = false, features = [
+    "std",
     "NSArray",
     "NSString",
     "NSURL",
 ] }
-objc2-app-kit = { version = "0.2.0", features = ["NSPasteboard"] }
+objc2-app-kit = { version = "0.2.0", default-features = false, features = [
+    "std",
+    "NSPasteboard",
+] }


### PR DESCRIPTION
The next version of the `objc2` framework crates will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).