### PR TITLE
Make X11 and Wayland configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ readme = "README.md"
 keywords = ["clipboard", "window", "ui", "gui", "raw-window-handle"]
 categories = ["gui"]
 
+[features]
+default = ["x11", "wayland"]
+x11 = ["clipboard_x11"]
+wayland = ["clipboard_wayland"]
+
 [dependencies]
 raw-window-handle = { version = "0.6", features = ["std"] }
 thiserror = "1.0"
@@ -22,8 +27,8 @@ clipboard-win = { version = "5.0", features = ["std"] }
 clipboard_macos = { version = "0.1", path = "./macos" }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten", target_os="ios", target_os="redox"))))'.dependencies]
-clipboard_x11 = { version = "0.4.2", path = "./x11" }
-clipboard_wayland = { version = "0.2.2", path = "./wayland" }
+clipboard_x11 = { version = "0.4.2", path = "./x11", optional = true }
+clipboard_wayland = { version = "0.2.2", path = "./wayland", optional = true }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
In the case that an app doesn't support both X11 and Wayland, disabling the respective feature saves on dependencies.