### PR TITLE
Update `thiserror` to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ wayland = ["clipboard_wayland"]
 
 [dependencies]
 raw-window-handle = { version = "0.6", features = ["std"] }
-thiserror = "1.0"
+thiserror = "2.0"
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "5.0", features = ["std"] }

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["clipboard", "x11"]
 
 [dependencies]
 x11rb = "0.13"
-thiserror = "1.0"
+thiserror = "2.0"


### PR DESCRIPTION
Just looking through my duplicate dependency versions again, saw this was one of the only crates that still depends on `thiserror@1`.